### PR TITLE
Ensuredatabaseexists

### DIFF
--- a/databear/databearDB.py
+++ b/databear/databearDB.py
@@ -11,8 +11,8 @@ DataBear database manager class
 
 '''
 
-import yaml
 import json
+import os
 import sqlite3
 
 
@@ -36,13 +36,10 @@ class DataBearDB:
         self.conn = sqlite3.connect('databear.db')
         self.curs = self.conn.cursor()
 
-    def ensureExists(self):
-        # Check if the database file exists
-        # If it exists create sqlite object and open it
+        with open(self.path + '/databearDB.sql', 'r') as sql_init_file:
+            sql_script = sql_init_file.read()
 
-        # If it doesn't exist use database creation script to
-        # initialize the database then create sqlite object and open it.
-        pass
+        self.dbcursor.executescript(sql_script)
 
     # Configuration getters and setters, Getters will need to be changed to return
     # either a dictionary of the configuration or some other type, skeleton for now

--- a/databear/databearDBv2.sql
+++ b/databear/databearDBv2.sql
@@ -51,12 +51,6 @@ CREATE TABLE IF NOT EXISTS "processes" (
 	"name"	TEXT NOT NULL,
 	"description"	TEXT NOT NULL
 );
-CREATE TABLE IF NOT EXISTS "users" (
-	"user_id"	INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
-	"username"	TEXT NOT NULL,
-	"password_hash"	TEXT,
-	"permission_level"	INTEGER
-);
 INSERT INTO "sensors" ("sensor_id","name","serial_number","address","virtualport","sensor_type","description") VALUES (1,'simulator','0',NULL,'port0','dbSim','Default simulator sensor');
 INSERT INTO "measurements" ("measurement_id","sensor_id","name","units","description") VALUES (1,1,'simsecond','second','The first simulator measurement.');
 INSERT INTO "processes" ("process_id","name","description") VALUES (1,'Sample','Select the first measurement from storage interval for storage'),

--- a/databear/logger.py
+++ b/databear/logger.py
@@ -6,6 +6,7 @@ The DataBear data logger
 
 import databear.schedule as schedule
 import databear.process as processdata
+import databear.databearDB as databearDB
 from databear import sensorfactory
 from databear.errors import DataLogConfigError, MeasureError
 from databear.databearDB import DataBearDB
@@ -55,6 +56,7 @@ class DataLogger:
         self.sel.register(self.udpsocket,selectors.EVENT_READ)
         self.listen = False
         self.messages = []
+        self.db = databearDB.DataBearDB(config)
 
         #Set up error logging
         logging.basicConfig(


### PR DESCRIPTION
This adds the basic ensuring the databear.db exists and loads it with what's in the DB.sql file at initialization. I'll get the databear configuration methods implemented today also most likely but in a different pull request.