### PR TITLE
Use subprocess.Popen to launch logger.py with python (using sys.executable)

### DIFF
--- a/databear/databearCLI.py
+++ b/databear/databearCLI.py
@@ -53,11 +53,12 @@ def runDataBear(yamlfile=None):
         shtdwnrsp = sendCommand('shutdown')
         print(shtdwnrsp)
     
-    #Run logger
-    # *** subprocess ***
-    dblogger = logger.DataLogger()
-    dblogger.loadconfig()
-    dblogger.run()
+    #Run logger in the background
+    print("Running databear with " + sys.executable + " databear/logger.py")
+    subprocess.Popen([sys.executable, './databear/logger.py'],
+                     cwd="./",
+                     stdout=subprocess.PIPE,
+                     stderr=subprocess.STDOUT)
 
 def sendCommand(command,argument=None):
     '''
@@ -112,12 +113,5 @@ def main_cli():
         rsp = sendCommand(cmd)
         print(rsp)
 
-
-
-
-
-    
-
-
-
-
+if __name__ == "__main__":
+    main_cli()

--- a/databear/logger.py
+++ b/databear/logger.py
@@ -396,6 +396,14 @@ class DataLogger:
         self.db.close()
       
             
+def main():
+    logger = DataLogger()
+    logger.loadconfig()
+    logger.run()
+
+if __name__ == "__main__":
+    main()
+
 
 
 


### PR DESCRIPTION
To use this without doing pip install set PYTHONPATH to where you have DataBear checked out. (so imports of databear/foo will work) then use python databear/databearCLI.py run

Running python databear/logger.py
directly shows there's still a bug in logger.py when it creates a sensor object, but I think populating the sensorclass table will fix that.