### PR TITLE
Runemptydb

### DIFF
--- a/databear/logger.py
+++ b/databear/logger.py
@@ -354,7 +354,8 @@ class DataLogger:
 
         #Create threadpool for concurrent sensor measurement
         self.workerpool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(self.sensors))
+            # use at least 1 worker
+            max_workers=max(len(self.sensors),1))
 
         while True:
             try:

--- a/databear/schedule.py
+++ b/databear/schedule.py
@@ -64,7 +64,10 @@ class Scheduler:
         :return: Number of seconds until
                  :meth:`next_run <Scheduler.next_run>`.
         """
-        return (self.next_run - datetime.datetime.now()).total_seconds()
+        if (self.next_run):
+            return (self.next_run - datetime.datetime.now()).total_seconds()
+        # There's no jobs, so just wait for 1 second
+        return 1
 
     def _run_job(self, job):
         ret = job.run()


### PR DESCRIPTION
These 2 changes make it so I am able to run python databear/logger.py with no sensors or other configuration set up at all. It doesn't do anything, but runs waiting for commands such as reload/shutdown, etc. I think with this the web ui should be able to modify the config then tell it to reload or restart once it has finished modifying configuration tables.