### PR TITLE
Fix the path to the databear logger.py when executed by databearCLI.py.

### DIFF
--- a/databear/databearCLI.py
+++ b/databear/databearCLI.py
@@ -12,6 +12,7 @@ others under development
 '''
 import socket
 import json
+import os
 import sys
 from databear import logger, databearDB
 import sqlite3
@@ -81,17 +82,15 @@ def runDataBear(yamlfile=None):
         shtdwnrsp = sendCommand('shutdown')
         print(shtdwnrsp)
     
+    databearpath = os.path.dirname(__file__)
+    loggerpath = os.path.join(databearpath, "logger.py")
     #Run logger in the background
-    '''
-    print("Running databear with " + sys.executable + " databear/logger.py")
-    subprocess.Popen([sys.executable, './databear/logger.py'],
+    print("Running databear with " + sys.executable + " " + loggerpath)
+    subprocess.Popen([sys.executable, loggerpath],
                      cwd="./",
                      stdout=subprocess.PIPE,
                      stderr=subprocess.PIPE)
-    '''
-    print('Running databear')
-    subprocess.run(['python','-m','databear.logger'],stdout=subprocess.PIPE)
-    
+        
 
 def updateAvailableSensors():
     '''


### PR DESCRIPTION
With this commit I'm able to run on windows with these 2 variables set as indicated:

PYTHONPATH="/c/data/devel/dyacon/DataBear"
DBDRIVER="databear.drivers.windriver"

I made an empty databear test folder next to my git checkout of DataBear and ran like this:

python ../DataBear/databear/databearCLI.py run

On the first time I tried that I didn't get a response from the status request message as expected. then the second time I ran that I got an OK back and it told it to shut down and ran a new instance. It seems to be working, but I didn't try with a yaml yet.