### PR TITLE
Don't call logger.loadConfig() from logger.py main since run calls it.

### DIFF
--- a/databear/logger.py
+++ b/databear/logger.py
@@ -404,7 +404,6 @@ class DataLogger:
             
 def main():
     logger = DataLogger()
-    logger.loadconfig()
     logger.run()
 
 if __name__ == "__main__":


### PR DESCRIPTION
To avoid duplicate data only call loadConfig() once from within run().
We may want to remove current schedule and sensors, etc. if loadConfig
is called multiple times, but for now just don't do it to avoid
duplication.