### PR TITLE
Fix high cpu usage by udp socket listener.

### DIFF
--- a/databear/logger.py
+++ b/databear/logger.py
@@ -291,7 +291,7 @@ class DataLogger:
         '''
         while self.listen:
             #Check for UDP comm
-            event = self.sel.select(timeout=0)
+            event = self.sel.select(timeout=None)
             if event:
                 self.readUDP()
 


### PR DESCRIPTION
Use timeout=None instead of timeout=0 to make the listenUDP thread
wait for events on the udp socket instead of running the cpu checking
over and over for a message without blocking.

As described here: https://docs.python.org/3/library/selectors.html#selectors.BaseSelector.select I think we want to use timeout=None so we only wake up that thread when there are messages rather than spinning checking over and over constantly. The timeout is a max timeout, I believe if there are messages a timeout such as 1 or 2 would return before the 1 or 2 second timeout, but I figured None was best, to eliminate the cpu usage completely.