### PR TITLE
Fix shutdown requiring a second command to actually shutdown.

### DIFF
--- a/databear/logger.py
+++ b/databear/logger.py
@@ -291,7 +291,7 @@ class DataLogger:
         '''
         while self.listen:
             #Check for UDP comm
-            event = self.sel.select(timeout=None)
+            event = self.sel.select(timeout=1)
             if event:
                 self.readUDP()
 


### PR DESCRIPTION
Since the process socket commands thread was blocking on command
input the t.join didn't ever finish (since the thread never checked
self.listen to quit when false). So don't block but use a timeout of 1
second when listening for incoming commands, checking for self.listen
after each timeuot.