### PR TITLE
Construct a DataBearDB to initialize databear.db if it's missing.

### DIFF
--- a/databear/databearCLI.py
+++ b/databear/databearCLI.py
@@ -33,6 +33,9 @@ def runDataBear(yamlfile=None):
     #Parse YAML file and load to database
     if yamlfile:
         loadYAML(yamlfile)
+    else:
+        # Initialize the database if needed
+        db = databearDB.DataBearDB()
         
     #Check to see if logger is already running
     #If so, shutdown for restart


### PR DESCRIPTION
If no yaml file is given to databear run just construct
a DataBearDB object so it will initialize databear.db if needed.