### PR TITLE
Include databearDB.sql in installed files next to python scripts.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include databear/databearDB.sql

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=['pyyaml'],
+    include_package_data=True,
     python_requires='>=3.6',
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
For DataBearDB to initialize properly it requires databearDB.sql
to be next to the other databear scripts.