### PR TITLE
Add DBSENSORPATH to python path if it's set.

### DIFF
--- a/databear/databearDB.py
+++ b/databear/databearDB.py
@@ -25,6 +25,10 @@ class DataBearDB:
             -- Create if needed
         - Create connection to database
         '''
+        # Add SENSORSPATH to pythonpath for importing alternative sensors
+        if 'DBSENSORPATH' in os.environ:
+            sys.path.append(os.environ['DBSENSORPATH'])
+
         #Set an attribute for config_id related functions
         self.configtables = {
             'sensor':['sensor_config_id','sensor_configuration'],

--- a/databear/logger.py
+++ b/databear/logger.py
@@ -40,6 +40,10 @@ class DataLogger:
         dbdriver:
             - An instance of a DB hardware driver
         '''
+        # Add SENSORSPATH to pythonpath for importing alternative sensors
+        if 'DBSENSORPATH' in os.environ:
+            sys.path.append(os.environ['DBSENSORPATH'])
+
         #Initialize attributes
         self.sensors = {}
         self.loggersettings = [] #Form (<measurement>,<sensor>)


### PR DESCRIPTION
To allow using sensors that aren't in databear.sensors or PYTHONPATH
add DBSENSORPATH value to PYTHONPATH if set.
Allows using pymdl.databear.sensors classes as sensors on mdl.