### PR TITLE
Expose uses_portlock sensor setting.

### DIFF
--- a/databear/logger.py
+++ b/databear/logger.py
@@ -159,7 +159,7 @@ class DataLogger:
 
         #"Connect" sensor to hardware
         #bus type ports are given thread locks
-        if virtualport[0:3] == 'bus':
+        if sensor.uses_portlock: 
             plock = self.portlocks.get(virtualport)
             if not plock:
                 plock = threading.Lock()

--- a/databear/sensors/dyaconTPH1B.py
+++ b/databear/sensors/dyaconTPH1B.py
@@ -22,6 +22,7 @@ class dyaconTPH1B(sensor.BusSensor):
         'barometric_pressure':'mb'
     }
     min_interval = 1  #Minimum interval that sensor can be polled
+    uses_portlock = True
     registers = {
             'air_temperature':201,
             'relative_humidity':202,

--- a/databear/sensors/dyaconTPH1C.py
+++ b/databear/sensors/dyaconTPH1C.py
@@ -23,6 +23,7 @@ class dyaconTPH1C(sensor.BusSensor):
         'barometric_pressure':'mb'
     }
     min_interval = 1  #Minimum interval that sensor can be polled
+    uses_portlock = True
     registers = {
         'air_temperature':210,
         'relative_humidity':212,

--- a/databear/sensors/sensor.py
+++ b/databear/sensors/sensor.py
@@ -12,6 +12,7 @@ class Sensor:
     units = {} #List of units associated with measurement names
     measurement_description = {}
     min_interval = 1  #Minimum interval that sensor can be polled
+    uses_portlock = False # Set to true in all sensor classes that require a portlock (modbus sensors)
     def __init__(self,name,sn,address):
         '''
         Create a new sensor


### PR DESCRIPTION
Instead of checking if port starts with "bus" just
check if the sensor class set uses_portlock to true
and use port locks in that case when connecting.
Also sets uses_portlock in both dyacon TPH nesor classes.
Base class uses_portlock is False.