### PR TITLE
Remove unque constraint on sensor_id, status.

### DIFF
--- a/databear/databearDB.sql
+++ b/databear/databearDB.sql
@@ -31,7 +31,6 @@ CREATE TABLE IF NOT EXISTS "sensor_configuration" (
 	"measure_interval"	REAL NOT NULL,
 	"status"    INTEGER,
 	FOREIGN KEY("sensor_id") REFERENCES "sensors"("sensor_id") ON DELETE CASCADE,
-	UNIQUE("sensor_id","status"),
 	PRIMARY KEY("sensor_config_id" AUTOINCREMENT)
 );
 CREATE TABLE IF NOT EXISTS "logging_configuration" (


### PR DESCRIPTION
Every time we edit a sensor configuration we mark the currently
active one as inactive, but it's still there for old data.
If a user edits a sensor more than once there will be more than one
sensor_configuration with the same sensor_id and status 0 for inactive.