### PR TITLE
Implement reload command.

### DIFF
--- a/databear/databearDB.py
+++ b/databear/databearDB.py
@@ -40,7 +40,7 @@ class DataBearDB:
 
         # Initialize database sqlite connection object
         # This will create the file if it doesn't exist, hence the check first
-        self.conn = sqlite3.connect('databear.db')
+        self.conn = sqlite3.connect('databear.db', check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
         self.curs = self.conn.cursor()
         self.path = os.path.dirname(__file__)


### PR DESCRIPTION
In order for reload command to work with sqlite databearDB
needed to be tweaked to add check_same_thread=False to the connect
method so multiple threads (run thread and process udp command thread)
can both use the self.db object.
Since reload first stops all jobs before it calls loadconfig this
should be safe, If needed we can add a mutex later on in the
databearDB class around all writes.