### PR TITLE
Check incoming messages are valid json.

### DIFF
--- a/databear/logger.py
+++ b/databear/logger.py
@@ -360,7 +360,14 @@ class DataLogger:
         msgraw, address = self.udpsocket.recvfrom(1024)
 
         #Decode message
-        msg = json.loads(msgraw)
+        try:
+            msg = json.loads(msgraw)
+        except:
+            logging.warning('Message not valid json, ignoring {}'.format(msgraw))
+            # Create an empty msg dict so we will send invalid command response
+            msg = {}
+            msg['command'] = 'invalid'
+
         if msg['command'] == 'getdata':
             sensorname = msg['arg']
             data = self.sensors[sensorname].getcurrentdata()


### PR DESCRIPTION
If incoming socket messages are not valid json, don't kill the
socket reading thread with an exception, just respond that the
command is invalid.
Fixes socket thread dying if others send invalid json, for example
"reload" is not valid json, while {"command": "reload"} is.